### PR TITLE
build(deps): bump org.junit.jupiter:junit-jupiter from 5.11.3 to 5.12.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ ext {
     kafkaVersion = "2.0.1"
     testcontainersVersion = "1.20.4"
     debeziumVersion = "1.3.0.Final"
+    junit5Version = "5.12.2"
 }
 
 distributions {
@@ -97,7 +98,7 @@ dependencies {
 
     implementation "org.slf4j:slf4j-api:1.7.36"
 
-    testImplementation "org.junit.jupiter:junit-jupiter:5.11.3"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit5Version"
     testImplementation "org.apache.kafka:connect-api:$kafkaVersion"
     testImplementation "org.testcontainers:junit-jupiter:$testcontainersVersion"
     testImplementation "io.debezium:debezium-api:$debeziumVersion"
@@ -106,6 +107,7 @@ dependencies {
     testRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:2.23.1"
     testRuntimeOnly "org.apache.logging.log4j:log4j-api:2.23.1"
     testRuntimeOnly "org.apache.logging.log4j:log4j-core:2.23.1"
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     integrationTestImplementation "org.apache.kafka:connect-api:$kafkaVersion"
     integrationTestImplementation("org.apache.kafka:connect-runtime:$kafkaVersion") {


### PR DESCRIPTION
Fix the dependabot version #168.  Migrating to Junit5 5.12.x requires a  `junit-platform-launcher` with gradle.