### PR TITLE
build(deps): bump org.apache.logging.log4j:log4j from 2.23.1 to 2.24.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ targetCompatibility = JavaVersion.VERSION_11
 ext {
     jacksonVersion = "2.18.2"
     kafkaVersion = "2.0.1"
+    log4jVersion = "2.24.3"
     testcontainersVersion = "1.20.4"
     debeziumVersion = "1.3.0.Final"
 }
@@ -103,9 +104,9 @@ dependencies {
     testImplementation "io.debezium:debezium-api:$debeziumVersion"
     testImplementation "org.assertj:assertj-core:3.26.3"
 
-    testRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:2.23.1"
-    testRuntimeOnly "org.apache.logging.log4j:log4j-api:2.23.1"
-    testRuntimeOnly "org.apache.logging.log4j:log4j-core:2.23.1"
+    testRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+    testRuntimeOnly "org.apache.logging.log4j:log4j-api:$log4jVersion"
+    testRuntimeOnly "org.apache.logging.log4j:log4j-core:$log4jVersion"
 
     integrationTestImplementation "org.apache.kafka:connect-api:$kafkaVersion"
     integrationTestImplementation("org.apache.kafka:connect-runtime:$kafkaVersion") {


### PR DESCRIPTION
Bumps all of the org.apache.logging.log4j:log4j-slf4j-impl 2.23.1 to 2.24.3.

This fixes the dependabot PRs #163 , #164 and #165 which inconsistently bumped the jars independently.