### PR TITLE
Add FieldValueMatches predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,37 @@ transforms.copyKey.type=io.aiven.kafka.connect.transforms.KeyToValue
 transforms.copyKey.key.fields=*
 ```
 
+## Predicates
+
+Kafka Connect allows a transformation to be applied conditionally by attaching a [predicate](https://kafka.apache.org/43/kafka-connect/user-guide/#predicates). This collection provides the following predicates.
+
+### `FieldValueMatches`
+
+This predicate is satisfied when a field in the record value equals an expected value or matches a regular expression. The field is addressed using Kafka Connect's [field path syntax](https://kafka.apache.org/documentation/#connect_transforms) (see `field.syntax.version`). Both schema-based (Avro) and schemaless (e.g. JSON) values are supported. If the field is empty, the whole value is considered.
+
+The predicate defines the following configurations:
+
+- `field` - The field in the record value to evaluate. With `field.syntax.version=V2` a dot-separated path navigates into nested structures (e.g. `after.state`); a field name that itself contains a dot can be wrapped in backticks (e.g. `` `a.b` ``). If empty, the whole value is used.
+- `value` - The expected value the field is compared to. Matches string, numeric and boolean fields. An empty string is a valid value. Either define this or `value.pattern`.
+- `value.pattern` - A regular expression the whole field value must match (a full match, not a substring search); an empty pattern matches only an empty string. Either define this or `value`.
+- `field.syntax.version` - The field path syntax version, `V1` (default, root-level fields only) or `V2` (nested paths). Set to `V2` to address a field inside a nested structure.
+
+To satisfy the predicate on the *non*-matching records instead, use Kafka Connect's built-in `negate` option on the predicate.
+
+Here is an example that converts Debezium soft-delete events into tombstones (note `field.syntax.version=V2`, since `after.state` is a nested field):
+
+```properties
+transforms=makeTombstone
+transforms.makeTombstone.type=io.aiven.kafka.connect.transforms.MakeTombstone
+transforms.makeTombstone.predicate=isSoftDeleted
+
+predicates=isSoftDeleted
+predicates.isSoftDeleted.type=io.aiven.kafka.connect.predicates.FieldValueMatches
+predicates.isSoftDeleted.field=after.state
+predicates.isSoftDeleted.value=deleted
+predicates.isSoftDeleted.field.syntax.version=V2
+```
+
 ## License
 
 This project is licensed under the [Apache License, Version 2.0](LICENSE).

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ ext {
     debeziumVersion = "1.3.0.Final"
     jacksonVersion = "2.19.0"
     junit5Version = "5.12.2"
-    kafkaVersion = "2.0.1"
+    kafkaVersion = "3.8.1"
     log4jVersion = "2.24.3"
     testcontainersVersion = "1.21.3"
 }
@@ -95,12 +95,14 @@ configurations {
 
 dependencies {
     compileOnly "org.apache.kafka:connect-api:$kafkaVersion"
+    compileOnly "org.apache.kafka:connect-transforms:$kafkaVersion"
     compileOnly "io.debezium:debezium-api:$debeziumVersion"
 
     implementation "org.slf4j:slf4j-api:1.7.36"
 
     testImplementation "org.junit.jupiter:junit-jupiter:$junit5Version"
     testImplementation "org.apache.kafka:connect-api:$kafkaVersion"
+    testImplementation "org.apache.kafka:connect-transforms:$kafkaVersion"
     testImplementation "org.testcontainers:junit-jupiter:$testcontainersVersion"
     testImplementation "io.debezium:debezium-api:$debeziumVersion"
     testImplementation "org.assertj:assertj-core:3.27.3"
@@ -120,6 +122,10 @@ dependencies {
     integrationTestImplementation "org.testcontainers:junit-jupiter:$testcontainersVersion"
     integrationTestImplementation("com.fasterxml.jackson.core:jackson-core:$jacksonVersion")
     integrationTestImplementation "org.testcontainers:kafka:$testcontainersVersion" // this is not Kafka version
+
+    // Kafka's connect-runtime REST layer references log4j 1.x (org.apache.log4j.Logger);
+    // bridge it onto log4j2 so the embedded Connect worker can start.
+    integrationTestRuntimeOnly "org.apache.logging.log4j:log4j-1.2-api:$log4jVersion"
     // Make test utils from 'test' available in 'integration-test'
     integrationTestImplementation sourceSets.test.output
 }

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -5,6 +5,6 @@ WORKDIR transforms
 
 RUN ./gradlew installDist
 
-FROM confluentinc/cp-kafka-connect:7.3.3
+FROM confluentinc/cp-kafka-connect:7.8.0
 
 COPY --from=base /transforms/build/install/transforms-for-apache-kafka-connect /transforms

--- a/demo/README.md
+++ b/demo/README.md
@@ -39,7 +39,7 @@ Copy the directory with libraries into your Kafka Connect nodes.
 e.g. add directory to Docker images:
 
 ```dockerfile
-FROM confluentinc/cp-kafka-connect:7.3.3
+FROM confluentinc/cp-kafka-connect:7.8.0
 
 COPY --from=base /transforms/build/install/transforms-for-apache-kafka-connect /transforms
 ```

--- a/demo/compose.yml
+++ b/demo/compose.yml
@@ -1,14 +1,14 @@
 version: '3.8'
 services:
   zookeeper:
-    image: "confluentinc/cp-zookeeper:7.3.3"
+    image: "confluentinc/cp-zookeeper:7.8.0"
     ports:
       - "2181:2181"
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
 
   kafka:
-    image: "confluentinc/cp-kafka:7.3.3"
+    image: "confluentinc/cp-kafka:7.8.0"
     ports:
       - "9092:9092"
     environment:

--- a/src/integration-test/java/io/aiven/kafka/connect/transforms/ConnectRunner.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/transforms/ConnectRunner.java
@@ -22,12 +22,15 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy;
+import org.apache.kafka.connect.connector.policy.NoneConnectorClientConfigOverridePolicy;
 import org.apache.kafka.connect.runtime.Connect;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.runtime.Herder;
 import org.apache.kafka.connect.runtime.Worker;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
-import org.apache.kafka.connect.runtime.rest.RestServer;
+import org.apache.kafka.connect.runtime.rest.ConnectRestServer;
+import org.apache.kafka.connect.runtime.rest.RestClient;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
 import org.apache.kafka.connect.runtime.standalone.StandaloneHerder;
@@ -48,7 +51,7 @@ final class ConnectRunner {
     private Connect connect;
 
     public ConnectRunner(final File pluginDir,
-                         final String bootstrapServers) {
+            final String bootstrapServers) {
         this.pluginDir = pluginDir;
         this.bootstrapServers = bootstrapServers;
     }
@@ -59,7 +62,8 @@ final class ConnectRunner {
 
         workerProps.put("offset.flush.interval.ms", "5000");
 
-        // These don't matter much (each connector sets its own converters), but need to be filled with valid classes.
+        // These don't matter much (each connector sets its own converters), but need to
+        // be filled with valid classes.
         workerProps.put("key.converter", "org.apache.kafka.connect.converters.ByteArrayConverter");
         workerProps.put("value.converter", "org.apache.kafka.connect.converters.ByteArrayConverter");
         workerProps.put("internal.key.converter", "org.apache.kafka.connect.json.JsonConverter");
@@ -78,11 +82,22 @@ final class ConnectRunner {
         final Plugins plugins = new Plugins(workerProps);
         final StandaloneConfig config = new StandaloneConfig(workerProps);
 
-        final Worker worker = new Worker(
-            workerId, time, plugins, config, new MemoryOffsetBackingStore());
-        herder = new StandaloneHerder(worker, "cluster-id");
+        final ConnectorClientConfigOverridePolicy clientConfigOverridePolicy =
+                new NoneConnectorClientConfigOverridePolicy();
 
-        final RestServer rest = new RestServer(config);
+        final Worker worker = new Worker(
+                workerId, time, plugins, config, new MemoryOffsetBackingStore() {
+                    @Override
+                    public java.util.Set<java.util.Map<String, Object>> connectorPartitions(
+                            final String connectorName) {
+                        return java.util.Collections.emptySet();
+                    }
+                }, clientConfigOverridePolicy);
+        herder = new StandaloneHerder(worker, "cluster-id", clientConfigOverridePolicy);
+
+        final RestClient restClient = new RestClient(config);
+        final ConnectRestServer rest = new ConnectRestServer(config.rebalanceTimeout(), restClient, config.originals());
+        rest.initializeServer();
 
         connect = new Connect(herder, rest);
 
@@ -93,20 +108,19 @@ final class ConnectRunner {
         assert herder != null;
 
         final FutureCallback<Herder.Created<ConnectorInfo>> cb = new FutureCallback<>(
-            new Callback<Herder.Created<ConnectorInfo>>() {
-                @Override
-                public void onCompletion(final Throwable error, final Herder.Created<ConnectorInfo> info) {
-                    if (error != null) {
-                        log.error("Failed to create job");
-                    } else {
-                        log.info("Created connector {}", info.result().name());
+                new Callback<Herder.Created<ConnectorInfo>>() {
+                    @Override
+                    public void onCompletion(final Throwable error, final Herder.Created<ConnectorInfo> info) {
+                        if (error != null) {
+                            log.error("Failed to create job");
+                        } else {
+                            log.info("Created connector {}", info.result().name());
+                        }
                     }
-                }
-            });
+                });
         herder.putConnectorConfig(
-            config.get(ConnectorConfig.NAME_CONFIG),
-            config, false, cb
-        );
+                config.get(ConnectorConfig.NAME_CONFIG),
+                config, false, cb);
 
         final Herder.Created<ConnectorInfo> connectorInfoCreated = cb.get();
         assert connectorInfoCreated.created();

--- a/src/main/java/io/aiven/kafka/connect/predicates/FieldValueMatches.java
+++ b/src/main/java/io/aiven/kafka/connect/predicates/FieldValueMatches.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2026 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.predicates;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.Values;
+import org.apache.kafka.connect.transforms.field.FieldSyntaxVersion;
+import org.apache.kafka.connect.transforms.field.SingleFieldPath;
+
+/**
+ * A {@link org.apache.kafka.connect.transforms.predicates.Predicate} that matches a record when a
+ * field in its value equals an expected value or matches a regular expression.
+ *
+ * <p>The field is resolved with Kafka Connect's {@link SingleFieldPath}, whose behaviour is
+ * controlled by the {@code field.syntax.version} config (see {@link FieldSyntaxVersion}): {@code V1}
+ * (default) treats the configured name as a single root-level field, while {@code V2} interprets it
+ * as a path and can navigate into nested structures (e.g. {@code after.state}). Both schema-based
+ * (Avro) and schemaless (e.g. JSON) values are supported. If no field is configured, the whole value
+ * is used.
+ */
+public class FieldValueMatches<R extends ConnectRecord<R>>
+        implements org.apache.kafka.connect.transforms.predicates.Predicate<R> {
+
+    public static final String FIELD_CONFIG = "field";
+    public static final String VALUE_CONFIG = "value";
+    public static final String VALUE_PATTERN_CONFIG = "value.pattern";
+
+    private Optional<SingleFieldPath> fieldPath;
+    private Predicate<SchemaAndValue> condition;
+
+    @Override
+    public ConfigDef config() {
+        final ConfigDef configDef = new ConfigDef()
+                .define(FIELD_CONFIG,
+                        ConfigDef.Type.STRING,
+                        null,
+                        ConfigDef.Importance.HIGH,
+                        "The field in the record value the predicate is evaluated against, using the field "
+                                + "path syntax selected by '" + FieldSyntaxVersion.FIELD_SYNTAX_VERSION_CONFIG + "'. "
+                                + "Both schema-based (Avro) and schemaless (e.g. JSON) values are supported. "
+                                + "If empty, the whole value is used.")
+                .define(VALUE_CONFIG,
+                        ConfigDef.Type.STRING,
+                        null,
+                        ConfigDef.Importance.HIGH,
+                        "The expected value the field is compared to. Matches string, numeric and boolean fields. "
+                                + "An empty string is a valid value. "
+                                + "Either define this or '" + VALUE_PATTERN_CONFIG + "'.")
+                .define(VALUE_PATTERN_CONFIG,
+                        ConfigDef.Type.STRING,
+                        null,
+                        ConfigDef.Importance.HIGH,
+                        "A regular expression the whole field value must match (full match, not a substring "
+                                + "search); an empty pattern matches only an empty string. "
+                                + "Either define this or '" + VALUE_CONFIG + "'.");
+        return FieldSyntaxVersion.appendConfigTo(configDef);
+    }
+
+    @Override
+    public void configure(final Map<String, ?> configs) {
+        final AbstractConfig config = new AbstractConfig(config(), configs);
+
+        this.fieldPath = Optional.ofNullable(config.getString(FIELD_CONFIG))
+                .filter(name -> !name.isEmpty())
+                .map(name -> new SingleFieldPath(name, FieldSyntaxVersion.fromConfig(config)));
+
+        final Optional<String> expectedValue = Optional.ofNullable(config.getString(VALUE_CONFIG));
+        final Optional<String> valuePattern = Optional.ofNullable(config.getString(VALUE_PATTERN_CONFIG));
+        // A provided empty string is a valid, non-null configuration for both options:
+        // an empty 'value' matches the empty string, and an empty 'value.pattern' (a
+        // full match) matches only the empty string.
+        final boolean expectedValuePresent = expectedValue.isPresent();
+        final boolean regexPatternPresent = valuePattern.isPresent();
+        if (expectedValuePresent == regexPatternPresent) {
+            throw new ConfigException(
+                    "Either " + VALUE_CONFIG + " or " + VALUE_PATTERN_CONFIG
+                            + " has to be set to apply the predicate");
+        }
+
+        if (expectedValuePresent) {
+            // Compare the string representations of both sides so that, for example, a
+            // numeric field matches value=5 regardless of its concrete numeric type.
+            final String expected = expectedValue.get();
+            this.condition = schemaAndValue -> schemaAndValue != null
+                    && expected.equals(Values.convertToString(schemaAndValue.schema(), schemaAndValue.value()));
+        } else {
+            final Predicate<String> regexPredicate = compilePattern(valuePattern.get()).asMatchPredicate();
+            this.condition = schemaAndValue -> schemaAndValue != null
+                    && regexPredicate.test(Values.convertToString(schemaAndValue.schema(), schemaAndValue.value()));
+        }
+    }
+
+    private static Pattern compilePattern(final String pattern) {
+        try {
+            return Pattern.compile(pattern);
+        } catch (final PatternSyntaxException e) {
+            throw new ConfigException(VALUE_PATTERN_CONFIG, pattern, "Invalid regular expression: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public boolean test(final R record) {
+        if (record.value() == null) {
+            return condition.test(null);
+        }
+        return condition.test(extractFieldValue(record).orElse(null));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Optional<SchemaAndValue> extractFieldValue(final R record) {
+        final Object recordValue = record.value();
+        if (fieldPath.isEmpty()) {
+            return Optional.ofNullable(recordValue)
+                    .map(value -> new SchemaAndValue(record.valueSchema(), value));
+        }
+        final SingleFieldPath path = fieldPath.get();
+        // A field path can only be resolved against a Struct (schema-based) or a Map
+        // (schemaless);
+        // any other value type (e.g. a raw byte array or string) has no addressable
+        // field.
+        if (recordValue instanceof Struct) {
+            final Struct struct = (Struct) recordValue;
+            return Optional.ofNullable(path.fieldFrom(struct.schema()))
+                    .flatMap(field -> Optional.ofNullable(path.valueFrom(struct))
+                            .map(value -> new SchemaAndValue(field.schema(), value)));
+        }
+        if (recordValue instanceof Map) {
+            return Optional.ofNullable(path.valueFrom((Map<String, Object>) recordValue))
+                    .map(value -> new SchemaAndValue(Values.inferSchema(value), value));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/src/test/java/io/aiven/kafka/connect/predicates/FieldValueMatchesTest.java
+++ b/src/test/java/io/aiven/kafka/connect/predicates/FieldValueMatchesTest.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright 2026 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.predicates;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class FieldValueMatchesTest {
+
+    private static final String SYNTAX_V2 = "field.syntax.version";
+
+    private final Schema afterSchema = SchemaBuilder.struct()
+        .field("pk", Schema.STRING_SCHEMA)
+        .field("state", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+
+    private final Schema valueSchema = SchemaBuilder.struct()
+        .field("after", afterSchema)
+        .field("op", Schema.STRING_SCHEMA)
+        .build();
+
+    @Test
+    void shouldMatchWhenNestedFieldEqualsValue() {
+        final FieldValueMatches<SourceRecord> predicate = new FieldValueMatches<>();
+        predicate.configure(Map.of(
+            "field", "after.state",
+            "value", "deleted",
+            SYNTAX_V2, "V2"
+        ));
+
+        assertThat(predicate.test(structRecord("deleted")))
+            .as("record with matching nested field should satisfy the predicate")
+            .isTrue();
+        assertThat(predicate.test(structRecord("active")))
+            .as("record with non-matching nested field should not satisfy the predicate")
+            .isFalse();
+    }
+
+    @Test
+    void shouldNotMatchWhenNestedFieldIsMissing() {
+        final FieldValueMatches<SourceRecord> predicate = new FieldValueMatches<>();
+        predicate.configure(Map.of(
+            "field", "after.state",
+            "value", "deleted",
+            SYNTAX_V2, "V2"
+        ));
+
+        assertThat(predicate.test(structRecord(null)))
+            .as("record with null field value should not satisfy the predicate")
+            .isFalse();
+    }
+
+    @Test
+    void shouldMatchWithRegex() {
+        final FieldValueMatches<SourceRecord> predicate = new FieldValueMatches<>();
+        predicate.configure(Map.of(
+            "field", "after.state",
+            "value.pattern", "^del.*",
+            SYNTAX_V2, "V2"
+        ));
+
+        assertThat(predicate.test(structRecord("deleted")))
+            .as("record matching the regex should satisfy the predicate")
+            .isTrue();
+        assertThat(predicate.test(structRecord("active")))
+            .as("record not matching the regex should not satisfy the predicate")
+            .isFalse();
+    }
+
+    @Test
+    void shouldMatchNumericFieldValue() {
+        final Schema schema = SchemaBuilder.struct()
+            .field("count", Schema.INT32_SCHEMA)
+            .build();
+        final SourceRecord matching = new SourceRecord(null, null, "some_topic",
+            null, "key", schema, new Struct(schema).put("count", 5));
+        final SourceRecord nonMatching = new SourceRecord(null, null, "some_topic",
+            null, "key", schema, new Struct(schema).put("count", 6));
+
+        final FieldValueMatches<SourceRecord> predicate = new FieldValueMatches<>();
+        predicate.configure(Map.of(
+            "field", "count",
+            "value", "5"
+        ));
+
+        assertThat(predicate.test(matching))
+            .as("integer field equal to 5 should match value=5")
+            .isTrue();
+        assertThat(predicate.test(nonMatching))
+            .as("integer field not equal to 5 should not match value=5")
+            .isFalse();
+    }
+
+    @Test
+    void shouldRequireFullMatchForRegex() {
+        final FieldValueMatches<SourceRecord> predicate = new FieldValueMatches<>();
+        predicate.configure(Map.of(
+            "field", "after.state",
+            "value.pattern", "del",
+            SYNTAX_V2, "V2"
+        ));
+
+        assertThat(predicate.test(structRecord("del")))
+            .as("value fully matching the pattern should satisfy the predicate")
+            .isTrue();
+        assertThat(predicate.test(structRecord("undeleted")))
+            .as("value only containing the pattern as a substring should not satisfy the predicate")
+            .isFalse();
+    }
+
+    @Test
+    void shouldMatchNestedFieldContainingDotUsingBacktick() {
+        final Schema schema = SchemaBuilder.struct()
+            .field("a.b", Schema.STRING_SCHEMA)
+            .build();
+        final SourceRecord matching = new SourceRecord(null, null, "some_topic",
+            null, "key", schema, new Struct(schema).put("a.b", "x"));
+
+        final FieldValueMatches<SourceRecord> predicate = new FieldValueMatches<>();
+        predicate.configure(Map.of(
+            "field", "`a.b`",
+            "value", "x",
+            SYNTAX_V2, "V2"
+        ));
+
+        assertThat(predicate.test(matching))
+            .as("backtick-escaped field name containing a dot should match")
+            .isTrue();
+    }
+
+    @Test
+    void shouldSupportSchemalessValues() {
+        final FieldValueMatches<SourceRecord> predicate = new FieldValueMatches<>();
+        predicate.configure(Map.of(
+            "field", "after.state",
+            "value", "deleted",
+            SYNTAX_V2, "V2"
+        ));
+
+        assertThat(predicate.test(mapRecord("deleted")))
+            .as("matching map record should satisfy the predicate")
+            .isTrue();
+        assertThat(predicate.test(mapRecord("active")))
+            .as("non-matching map record should not satisfy the predicate")
+            .isFalse();
+    }
+
+    @Test
+    void shouldNotMatchWhenFieldConfiguredButValueIsNotStructOrMap() {
+        final FieldValueMatches<SourceRecord> predicate = new FieldValueMatches<>();
+        predicate.configure(Map.of(
+            "field", "after.state",
+            "value", "deleted",
+            SYNTAX_V2, "V2"
+        ));
+
+        final SourceRecord schemaButNotStruct = new SourceRecord(null, null, "some_topic",
+            null, "key", Schema.BYTES_SCHEMA, new byte[] {1, 2, 3});
+        final SourceRecord schemalessScalar = new SourceRecord(null, null, "some_topic",
+            null, "key", null, "raw");
+
+        assertThat(predicate.test(schemaButNotStruct))
+            .as("record with a non-Struct schema-based value should not satisfy the predicate")
+            .isFalse();
+        assertThat(predicate.test(schemalessScalar))
+            .as("record with a schemaless non-Map value should not satisfy the predicate")
+            .isFalse();
+    }
+
+    @Test
+    void shouldMatchWholeValueWhenFieldIsEmpty() {
+        final FieldValueMatches<SourceRecord> predicate = new FieldValueMatches<>();
+        predicate.configure(Map.of("value", "deleted"));
+
+        final SourceRecord matching = new SourceRecord(null, null, "some_topic",
+            null, "key", Schema.STRING_SCHEMA, "deleted");
+        final SourceRecord nonMatching = new SourceRecord(null, null, "some_topic",
+            null, "key", Schema.STRING_SCHEMA, "active");
+        assertThat(predicate.test(matching))
+            .as("record whose whole value matches should satisfy the predicate")
+            .isTrue();
+        assertThat(predicate.test(nonMatching))
+            .as("record whose whole value does not match should not satisfy the predicate")
+            .isFalse();
+    }
+
+    @Test
+    void shouldNotMatchTombstoneValue() {
+        final FieldValueMatches<SourceRecord> predicate = new FieldValueMatches<>();
+        predicate.configure(Map.of(
+            "field", "after.state",
+            "value", "deleted",
+            SYNTAX_V2, "V2"
+        ));
+
+        final SourceRecord tombstone = new SourceRecord(null, null, "some_topic",
+            Schema.STRING_SCHEMA, "key", null, null);
+        assertThat(predicate.test(tombstone))
+            .as("tombstone record should not satisfy the predicate")
+            .isFalse();
+    }
+
+    @Test
+    void shouldFailWhenNeitherValueNorPatternIsSet() {
+        final FieldValueMatches<SourceRecord> predicate = new FieldValueMatches<>();
+        assertThatThrownBy(() -> predicate.configure(Map.of("field", "after.state")))
+            .isInstanceOf(ConfigException.class);
+    }
+
+    @Test
+    void shouldFailWhenBothValueAndPatternAreSet() {
+        final FieldValueMatches<SourceRecord> predicate = new FieldValueMatches<>();
+        final Map<String, String> configs = new HashMap<>();
+        configs.put("field", "after.state");
+        configs.put("value", "deleted");
+        configs.put("value.pattern", "^del.*");
+        assertThatThrownBy(() -> predicate.configure(configs))
+            .isInstanceOf(ConfigException.class);
+    }
+
+    @Test
+    void shouldMatchEmptyStringValue() {
+        final FieldValueMatches<SourceRecord> predicate = new FieldValueMatches<>();
+        predicate.configure(Map.of(
+            "field", "after.state",
+            "value", "",
+            SYNTAX_V2, "V2"
+        ));
+
+        assertThat(predicate.test(structRecord("")))
+            .as("record whose field equals the empty string should satisfy the predicate")
+            .isTrue();
+        assertThat(predicate.test(structRecord("active")))
+            .as("record whose field is non-empty should not satisfy the predicate")
+            .isFalse();
+    }
+
+    @Test
+    void shouldFailWithConfigExceptionOnInvalidRegex() {
+        final FieldValueMatches<SourceRecord> predicate = new FieldValueMatches<>();
+        assertThatThrownBy(() -> predicate.configure(Map.of(
+            "field", "after.state",
+            "value.pattern", "[unclosed"
+        )))
+            .isInstanceOf(ConfigException.class);
+    }
+
+    private SourceRecord structRecord(final String state) {
+        final Struct after = new Struct(afterSchema).put("pk", "1");
+        if (state != null) {
+            after.put("state", state);
+        }
+        final Struct value = new Struct(valueSchema)
+            .put("after", after)
+            .put("op", "u");
+        return new SourceRecord(null, null, "some_topic",
+            Schema.STRING_SCHEMA, "key", valueSchema, value);
+    }
+
+    private SourceRecord mapRecord(final String state) {
+        final Map<String, Object> after = new HashMap<>();
+        after.put("pk", "1");
+        after.put("state", state);
+        final Map<String, Object> value = new HashMap<>();
+        value.put("after", after);
+        value.put("op", "u");
+        return new SourceRecord(null, null, "some_topic",
+            null, "key", null, value);
+    }
+}


### PR DESCRIPTION
Add a FieldValueMatches predicate that is satisfied when a field in the
record value equals an expected value or matches a regex. Field access
uses Kafka Connect's SingleFieldPath, so the field.syntax.version config
selects between V1 (root-level field, the default) and V2 (nested
dot-paths, with backtick escaping for names containing dots).

SingleFieldPath requires Kafka >= 3.8.0, so bump kafkaVersion from 2.0.1
to 3.8.1, add connect-transforms as a compileOnly/test dependency, and
adapt the integration-test harness to the newer runtime API:
 - pass a ConnectorClientConfigOverridePolicy to Worker/StandaloneHerder
 - build the REST layer via ConnectRestServer and let Connect.start()
initialize its resources
 - subclass the now-abstract MemoryOffsetBackingStore
 - add the log4j-1.2-api bridge so connect-runtime's REST layer can
start